### PR TITLE
Fix/sdk cpp warnings

### DIFF
--- a/beken378/driver/common/drv_model.c
+++ b/beken378/driver/common/drv_model.c
@@ -253,7 +253,7 @@ UINT32 ddev_control(DD_HANDLE handle, UINT32 cmd, VOID *param)
     return status;
 }
 
-UINT32 sddev_control(char *dev_name, UINT32 cmd, VOID *param)
+UINT32 sddev_control(const char *dev_name, UINT32 cmd, VOID *param)
 {
     UINT32 i;
     UINT32 status;

--- a/beken378/driver/include/drv_model_pub.h
+++ b/beken378/driver/include/drv_model_pub.h
@@ -45,7 +45,7 @@ extern UINT32 ddev_close(DD_HANDLE handle);
 extern UINT32 ddev_read(DD_HANDLE handle, char *user_buf , UINT32 count, UINT32 op_flag);
 extern UINT32 ddev_write(DD_HANDLE handle, char *user_buf , UINT32 count, UINT32 op_flag);
 extern UINT32 ddev_control(DD_HANDLE handle, UINT32 cmd, VOID *param);
-extern UINT32 sddev_control(char *dev_name, UINT32 cmd, VOID *param);
+extern UINT32 sddev_control(const char *dev_name, UINT32 cmd, VOID *param);
 extern UINT32 ddev_register_dev(char *dev_name, DD_OPERATIONS *optr);
 extern UINT32 sddev_register_dev(char *dev_name, SDD_OPERATIONS *optr);
 extern UINT32 ddev_unregister_dev(char *dev_name);

--- a/beken378/release/release.h
+++ b/beken378/release/release.h
@@ -3,9 +3,9 @@
 
 #include "sdk_revision.h"
 
-#define IP_11N_LIB_REV	"W4-"BEKEN_SDK_REV"-P0"		/* The SW revision of IP 11n lib */
-#define BLE_4X_LIB_REV	"B4-"BEKEN_SDK_REV"-P0"		/* The SW revision of BLE4.x lib */
-#define BLE_5X_LIB_REV	"B5-"BEKEN_SDK_REV"-P0"		/* The SW revision of BLE5.x lib */
-#define USB_2X_LIB_REV	"U2-"BEKEN_SDK_REV"-P0"		/* The SW revision of USB2.x lib */
+#define IP_11N_LIB_REV	"W4-" BEKEN_SDK_REV"-P0"		/* The SW revision of IP 11n lib */
+#define BLE_4X_LIB_REV	"B4-" BEKEN_SDK_REV"-P0"		/* The SW revision of BLE4.x lib */
+#define BLE_5X_LIB_REV	"B5-" BEKEN_SDK_REV"-P0"		/* The SW revision of BLE5.x lib */
+#define USB_2X_LIB_REV	"U2-" BEKEN_SDK_REV"-P0"		/* The SW revision of USB2.x lib */
 
 #endif


### PR DESCRIPTION
Исправил предупреждения g++ компилятора по поводу:
1. Остутствия пробела между строками в #define
2. преобразования строковго литерала в (char*)