### PR TITLE
Устранение утечек памяти при закрытии сокета

### DIFF
--- a/beken378/func/lwip_intf/lwip-2.0.2/src/api/sockets.c
+++ b/beken378/func/lwip_intf/lwip-2.0.2/src/api/sockets.c
@@ -1851,8 +1851,15 @@ lwip_shutdown(int s, int how)
   if (!sock) {
     return -1;
   }
-  SOCK_DEINIT_SYNC(sock);
-
+/*
+SBERDEVICES: start of changes
+Removed: SOCK_DEINIT_SYNC macro at socket shutdown
+Reason: fix issue with memory leaks if socket close() is called after shutdown()
+*/    
+//  SOCK_DEINIT_SYNC(sock);
+/*
+SBERDEVICES: end of changes
+*/    
   if (sock->conn != NULL) {
     if (NETCONNTYPE_GROUP(netconn_type(sock->conn)) != NETCONN_TCP) {
       sock_set_errno(sock, EOPNOTSUPP);


### PR DESCRIPTION
Из функции lwip_shutdown() убран макрос SOCK_DEINIT_SYNC, наличие которого приводило к утечкам памяти в ситуации, когда для сокета последовательно вызываются функции shutdown() и close()