### PR TITLE
Read flash Unique ID

### DIFF
--- a/beken378/beken.mk
+++ b/beken378/beken.mk
@@ -28,6 +28,7 @@ $(NAME)_INCLUDES := app/standalone-ap \
 					driver/jpeg \
 					driver/calendar \
 					driver/pwm \
+					driver/spi \
 					func/sdio_intf \
 					func/power_save \
 					func/temp_detect \

--- a/beken378/beken.mk
+++ b/beken378/beken.mk
@@ -28,7 +28,6 @@ $(NAME)_INCLUDES := app/standalone-ap \
 					driver/jpeg \
 					driver/calendar \
 					driver/pwm \
-					driver/spi \
 					func/sdio_intf \
 					func/power_save \
 					func/temp_detect \

--- a/beken378/driver/flash/flash.c
+++ b/beken378/driver/flash/flash.c
@@ -2,8 +2,6 @@
 #include "arm_arch.h"
 #include "sys_config.h"
 #include "flash.h"
-#include "icu.h"
-#include "spi_bl2028n.h"
 #include "sys_ctrl.h"
 #include "flash_pub.h"
 #include "drv_model_pub.h"
@@ -13,6 +11,12 @@
 #include "mcu_ps_pub.h"
 #include "mem_pub.h"
 #include "ate_app.h"
+#if CFG_UNIQUE_FLASH_ID
+#if (CFG_SOC_NAME == SOC_BL2028N)
+#include "icu.h"
+#include "spi_bl2028n.h"
+#endif
+#endif
 
 static const flash_config_t flash_config[] =
 {
@@ -610,9 +614,13 @@ void flash_protection_op(UINT8 mode, PROTECT_TYPE type)
 	set_flash_protect(type);
 }
 
-/*
-*/
+#if CFG_UNIQUE_FLASH_ID
 #if (CFG_SOC_NAME == SOC_BL2028N)
+/*
+  Read Unique ID Number from EN25QH16B flash - specific to BL2028N
+  This function must be executed from ITCM memory.
+  Code execution from flash is not allowed because of direct SPI interaction with flash memory.
+*/
 void flash_read_unique_id(void)
 {
     UINT32 value, reg_sctrl, reg_clk_pwd;
@@ -622,55 +630,55 @@ void flash_read_unique_id(void)
     GLOBAL_INT_DECLARATION();
     GLOBAL_INT_DISABLE();
 
-	reg_clk_pwd = REG_READ(ICU_PERI_CLK_PWD);
-	REG_WRITE(ICU_PERI_CLK_PWD, reg_clk_pwd & ~PWD_SPI_CLK);
+    reg_clk_pwd = REG_READ(ICU_PERI_CLK_PWD);
+    REG_WRITE(ICU_PERI_CLK_PWD, reg_clk_pwd & ~PWD_SPI_CLK);
 
     reg_sctrl = REG_READ(SCTRL_CONTROL);
     REG_WRITE(SCTRL_CONTROL, reg_sctrl | FLASH_SPI_MUX_BIT);
 
-	value = REG_READ(SPI_CONFIG);
-	value &= ~(0xFFF << SPI_TX_TRAHS_LEN_POSI);
-	value |= ((17 & 0xFFF) << SPI_TX_TRAHS_LEN_POSI);
+    value = REG_READ(SPI_CONFIG);
+    value &= ~(0xFFF << SPI_TX_TRAHS_LEN_POSI);
+    value |= ((17 & 0xFFF) << SPI_TX_TRAHS_LEN_POSI);
     REG_WRITE(SPI_CONFIG, value);
 
-	value = REG_READ(SPI_CONFIG);
+    value = REG_READ(SPI_CONFIG);
     value &= ~(0xFFF << SPI_RX_TRAHS_LEN_POSI);
-	value |= ((17 & 0xFFF) << SPI_RX_TRAHS_LEN_POSI);
+    value |= ((17 & 0xFFF) << SPI_RX_TRAHS_LEN_POSI);
     REG_WRITE(SPI_CONFIG, value);
 
-	value = REG_READ(SPI_CTRL);
-	value &= ~CTRL_NSSMD_3;
-	REG_WRITE(SPI_CTRL, value);
+    value = REG_READ(SPI_CTRL);
+    value &= ~CTRL_NSSMD_3;
+    REG_WRITE(SPI_CTRL, value);
 
     for (i = 0; i < 17; i++)
     {
-	    while (0 == (REG_READ(SPI_STAT) & TXFIFO_WR_READ));
+        while (0 == (REG_READ(SPI_STAT) & TXFIFO_WR_READ));
         REG_WRITE(SPI_DAT, flash_uid_command[i]);
     }
-    
-	value = REG_READ(SPI_CONFIG);
-	value |= (SPI_TX_EN | SPI_RX_EN);
-	REG_WRITE(SPI_CONFIG, value);
+
+    value = REG_READ(SPI_CONFIG);
+    value |= (SPI_TX_EN | SPI_RX_EN);
+    REG_WRITE(SPI_CONFIG, value);
 
     for (i = 0; i < 5; i++)
     {
         while (0 == (REG_READ(SPI_STAT) & RXFIFO_RD_READ));
         REG_READ(SPI_DAT);
     }
-    
+
     for (i = 0; i < 12; i++)
     {
         while (0 == (REG_READ(SPI_STAT) & RXFIFO_RD_READ));
         flash_unique_id.bytes[i] = REG_READ(SPI_DAT);
     }
 
-	value = REG_READ(SPI_CONFIG);
-	value &= ~(SPI_TX_EN | SPI_RX_EN);
-	REG_WRITE(SPI_CONFIG, value);
+    value = REG_READ(SPI_CONFIG);
+    value &= ~(SPI_TX_EN | SPI_RX_EN);
+    REG_WRITE(SPI_CONFIG, value);
 
-	value = REG_READ(SPI_CTRL);
-	value |= CTRL_NSSMD_3;
-	REG_WRITE(SPI_CTRL, value);
+    value = REG_READ(SPI_CTRL);
+    value |= CTRL_NSSMD_3;
+    REG_WRITE(SPI_CTRL, value);
 
     REG_WRITE(SCTRL_CONTROL, reg_sctrl);
     REG_WRITE(ICU_PERI_CLK_PWD, reg_clk_pwd);
@@ -679,22 +687,25 @@ void flash_read_unique_id(void)
     GLOBAL_INT_RESTORE();
 }
 #endif
+#endif
 
 void flash_init(void)
 {
     UINT32 id;
 
     while(REG_READ(REG_FLASH_OPERATE_SW) & BUSY_SW);
-	
+
     id = flash_get_id();
     FLASH_PRT("[Flash]id:0x%x\r\n", id);
     flash_get_current_flash_config();
 
+    #if CFG_UNIQUE_FLASH_ID
     #if (CFG_SOC_NAME == SOC_BL2028N)
     if (id == 0x1C7015)
     {
         flash_read_unique_id();
     }
+    #endif
     #endif
 
 	set_flash_protect(FLASH_UNPROTECT_LAST_BLOCK);
@@ -873,7 +884,11 @@ UINT32 flash_ctrl(UINT32 cmd, void *parm)
     return ret;
 }
 
+#if CFG_UNIQUE_FLASH_ID
 #if (CFG_SOC_NAME == SOC_BL2028N)
+/*
+  Interface function to get pointer to 96-bit Unique ID Number of Flash
+*/
 UINT32 flash_get_96bit_unique_id(UINT8** pointer)
 {
     if (flash_unique_id.type != FLASH_UNIQUE_ID_96BIT)
@@ -890,6 +905,7 @@ UINT32 flash_get_96bit_unique_id(UINT8** pointer)
 
     return FLASH_SUCCESS;
 }
+#endif
 #endif
 // eof
 

--- a/beken378/driver/flash/flash.h
+++ b/beken378/driver/flash/flash.h
@@ -65,11 +65,13 @@
 #define LINE_MODE_TWO                        2
 #define LINE_MODE_FOUR                       4
 
+#if CFG_UNIQUE_FLASH_ID
 typedef enum
 {
     FLASH_UNIQUE_ID_INVALID = 0,
     FLASH_UNIQUE_ID_96BIT = 1
 } FLASH_UNIQUE_ID_TYPE;
+#endif
 
 typedef enum
 {
@@ -112,11 +114,13 @@ typedef struct
     uint8_t  mode_sel;
 } flash_config_t;
 
+#if CFG_UNIQUE_FLASH_ID
 typedef struct
 {
     FLASH_UNIQUE_ID_TYPE  type;
     uint8_t               bytes[12];
 } flash_unique_id_t;
+#endif
 
 /*******************************************************************************
 * Function Declarations

--- a/beken378/driver/flash/flash.h
+++ b/beken378/driver/flash/flash.h
@@ -67,6 +67,12 @@
 
 typedef enum
 {
+    FLASH_UNIQUE_ID_INVALID = 0,
+    FLASH_UNIQUE_ID_96BIT = 1
+} FLASH_UNIQUE_ID_TYPE;
+
+typedef enum
+{
     FLASH_OPCODE_WREN    = 1,
     FLASH_OPCODE_WRDI    = 2,
     FLASH_OPCODE_RDSR    = 3,
@@ -105,6 +111,12 @@ typedef struct
     uint8_t  m_value;
     uint8_t  mode_sel;
 } flash_config_t;
+
+typedef struct
+{
+    FLASH_UNIQUE_ID_TYPE  type;
+    uint8_t               bytes[12];
+} flash_unique_id_t;
 
 /*******************************************************************************
 * Function Declarations

--- a/beken378/driver/include/flash_pub.h
+++ b/beken378/driver/include/flash_pub.h
@@ -64,7 +64,7 @@ extern void flash_set_line_mode(UINT8);
 extern UINT32 flash_read(char *user_buf, UINT32 count, UINT32 address);
 extern UINT32 flash_write(char *user_buf, UINT32 count, UINT32 address);
 #if (CFG_SOC_NAME == SOC_BL2028N)
-extern UINT32 flash_96bit_unique_id(UINT8** pointer);
+extern UINT32 flash_get_96bit_unique_id(UINT8** pointer);
 #endif
 #endif //_FLASH_PUB_H
 

--- a/beken378/driver/include/flash_pub.h
+++ b/beken378/driver/include/flash_pub.h
@@ -63,8 +63,10 @@ extern UINT8 flash_get_line_mode(void);
 extern void flash_set_line_mode(UINT8);
 extern UINT32 flash_read(char *user_buf, UINT32 count, UINT32 address);
 extern UINT32 flash_write(char *user_buf, UINT32 count, UINT32 address);
+#if CFG_UNIQUE_FLASH_ID
 #if (CFG_SOC_NAME == SOC_BL2028N)
 extern UINT32 flash_get_96bit_unique_id(UINT8** pointer);
+#endif
 #endif
 #endif //_FLASH_PUB_H
 

--- a/beken378/driver/include/flash_pub.h
+++ b/beken378/driver/include/flash_pub.h
@@ -63,5 +63,8 @@ extern UINT8 flash_get_line_mode(void);
 extern void flash_set_line_mode(UINT8);
 extern UINT32 flash_read(char *user_buf, UINT32 count, UINT32 address);
 extern UINT32 flash_write(char *user_buf, UINT32 count, UINT32 address);
+#if (CFG_SOC_NAME == SOC_BL2028N)
+extern UINT32 flash_96bit_unique_id(UINT8** pointer);
+#endif
 #endif //_FLASH_PUB_H
 


### PR DESCRIPTION
Reading of Unique ID Number from EN25QH16B flash (BL2028n).
Directly sends command "Read SFDP Mode and Unique ID Number" via internal SPI.
Obtains factory-set read-only 96-bit number that is unique to each device.