### PR TITLE
закомментировал макросы min/max

### DIFF
--- a/beken378/app/http/utils_httpc.c
+++ b/beken378/app/http/utils_httpc.c
@@ -514,7 +514,7 @@ void http_wr_to_flash(char *page, UINT32 len)
 	i = 0;
 	tmp = (UINT8 *)page;
 	while (i < len) {
-		w_l = min(len - i, HTTP_FLASH_WR_BUF_MAX - bk_http_ptr->wr_last_len);
+		w_l = MIN(len - i, HTTP_FLASH_WR_BUF_MAX - bk_http_ptr->wr_last_len);
 		os_memcpy(bk_http_ptr->wr_buf + bk_http_ptr->wr_last_len, tmp + i, w_l);
 		i += w_l;
 		bk_http_ptr->wr_last_len += w_l;

--- a/beken378/common/fifo.h
+++ b/beken378/common/fifo.h
@@ -104,10 +104,10 @@ __INLINE unsigned int kfifo_put(struct kfifo *fifo,
     GLOBAL_INT_DECLARATION();
 
     GLOBAL_INT_DISABLE();
-	len = min(len, fifo->size - fifo->in + fifo->out);
+	len = MIN(len, fifo->size - fifo->in + fifo->out);
 
 	/* first put the data starting from fifo->in to buffer end */
-	l = min(len, fifo->size - (fifo->in & (fifo->size - 1)));
+	l = MIN(len, fifo->size - (fifo->in & (fifo->size - 1)));
 	os_memcpy(fifo->buffer + (fifo->in & (fifo->size - 1)), buffer, l);
 
 	/* then put the rest (if any) at the beginning of the buffer */
@@ -138,10 +138,10 @@ __INLINE unsigned int kfifo_get(struct kfifo *fifo,
     GLOBAL_INT_DECLARATION();
 
     GLOBAL_INT_DISABLE();
-	len = min(len, fifo->in - fifo->out);
+	len = MIN(len, fifo->in - fifo->out);
 
 	/* first get the data from fifo->out until the end of the buffer */
-	l = min(len, fifo->size - (fifo->out & (fifo->size - 1)));
+	l = MIN(len, fifo->size - (fifo->out & (fifo->size - 1)));
 	os_memcpy(buffer, fifo->buffer + (fifo->out & (fifo->size - 1)), l);
 
 	/* then get the rest (if any) from the beginning of the buffer */
@@ -171,7 +171,7 @@ __INLINE void kfifo_copy_out(struct kfifo *fifo, void *dst,
 
 	off &= fifo->mask;
 
-	l = min(len, size - off);
+	l = MIN(len, size - off);
 
 	os_memcpy(dst, (void *)(fifo->buffer + off), l);
 	os_memcpy((void *)((unsigned int)dst + l), (void *)fifo->buffer, len - l);

--- a/beken378/common/generic.h
+++ b/beken378/common/generic.h
@@ -15,6 +15,7 @@ typedef void (*FUNC_2PARAM_PTR)(void *arg, uint8_t vif_idx);
 #define MIN(x, y)                  (((x) < (y)) ? (x) : (y))
 #endif
 
+/*
 #ifndef max
 #define max(x, y)                  (((x) > (y)) ? (x) : (y))
 #endif
@@ -22,6 +23,7 @@ typedef void (*FUNC_2PARAM_PTR)(void *arg, uint8_t vif_idx);
 #ifndef min
 #define min(x, y)                  (((x) < (y)) ? (x) : (y))
 #endif
+*/
 
 extern void bk_printf(const char *fmt, ...);
 #define as_printf (bk_printf("%s:%d\r\n",__FUNCTION__,__LINE__))

--- a/beken378/func/airkiss/airkiss_pingpong.c
+++ b/beken378/func/airkiss/airkiss_pingpong.c
@@ -30,7 +30,7 @@ uint32_t read_from_pingpong_buf(void *buf_user, const uint32_t count, uint32_t *
     }
     GLOBAL_INT_RESTORE();
 
-    len = min(count, buf->length - buf->offset);
+    len = MIN(count, buf->length - buf->offset);
 
 	os_memcpy(buf_user, buf->addr, len);
     ret += len;
@@ -73,7 +73,7 @@ uint32_t write_to_pingpong_buf(void *buf_user, const uint32_t count, const uint3
     GLOBAL_INT_RESTORE();
 
     /* use memset instead write operations for test */
-	len = min(BUF_LEN, count);
+	len = MIN(BUF_LEN, count);
 	os_memcpy(buf->addr, buf_user, len);
 	buf->actual = actual;
 

--- a/beken378/func/easy_flash/bk_ef.c
+++ b/beken378/func/easy_flash/bk_ef.c
@@ -93,7 +93,7 @@ EfErrCode bk_get_buf_env(const char *key, const char *buf, int len)
 
     if(out_len)
     {
-        count = min(len, out_len);
+        count = MIN(len, out_len);
         ASSERT(len == out_len);
 
         os_memcpy((void*)buf, out_ptr, count);


### PR DESCRIPTION
Надоели постоянно вылезающие проболемы с макрсоами min/max, которые конфликтуют с std::min std::max
в файле generic.h закомментировал min/max
везде заменил min/max на MIN/MAX
поправил wolfssl/user_config.h чтобы не использовал min/max