### PR TITLE
Fix errno

### DIFF
--- a/beken378/func/airkiss/bk_airkiss.c
+++ b/beken378/func/airkiss/bk_airkiss.c
@@ -3,7 +3,7 @@
 #include "airkiss.h"
 #include "mem_pub.h"
 #include "role_launch.h"
-#include "sockets.h"
+#include "lwip/sockets.h"
 
 static int bk_airkiss_decode_status;
 uint32_t airkiss_start_flag = 0;

--- a/beken378/func/airkiss/bk_airkiss.c
+++ b/beken378/func/airkiss/bk_airkiss.c
@@ -3,7 +3,7 @@
 #include "airkiss.h"
 #include "mem_pub.h"
 #include "role_launch.h"
-#include "lwip/sockets.h"
+#include "sockets.h"
 
 static int bk_airkiss_decode_status;
 uint32_t airkiss_start_flag = 0;

--- a/beken378/func/lwip_intf/lwip-2.0.2/port/lwipopts.h
+++ b/beken378/func/lwip_intf/lwip-2.0.2/port/lwipopts.h
@@ -345,7 +345,7 @@
  * TCP_LISTEN_BACKLOG==1: Handle backlog connections.
  */
 #define TCP_LISTEN_BACKLOG		        1
-#define LWIP_PROVIDE_ERRNO		        1 
+//#define LWIP_PROVIDE_ERRNO		        0 
 
 #include <errno.h>
 #define ERRNO				            1

--- a/beken378/func/lwip_intf/lwip-2.0.2/port/lwipopts.h
+++ b/beken378/func/lwip_intf/lwip-2.0.2/port/lwipopts.h
@@ -346,8 +346,7 @@
  */
 #define TCP_LISTEN_BACKLOG		        1
 //#define LWIP_PROVIDE_ERRNO		        0 
-
-#include <errno.h>
+#include <sys/errno.h>
 #define ERRNO				            1
 
 //#define LWIP_SNMP 1

--- a/beken378/func/paho-mqtt/client/paho_mqtt_udp.c
+++ b/beken378/func/paho-mqtt/client/paho_mqtt_udp.c
@@ -4,7 +4,7 @@
 #include "MQTTPacket.h"
 #include "paho_mqtt.h"
 #include <lwip/netdb.h>
-#include "lwip/sockets.h"
+#include "sockets.h"
 #include <arch/sys_arch.h>
 #include <lwip/sys.h>
 #include <lwip/netifapi.h>

--- a/beken378/func/paho-mqtt/client/paho_mqtt_udp.c
+++ b/beken378/func/paho-mqtt/client/paho_mqtt_udp.c
@@ -4,7 +4,7 @@
 #include "MQTTPacket.h"
 #include "paho_mqtt.h"
 #include <lwip/netdb.h>
-#include "sockets.h"
+#include "lwip/sockets.h"
 #include <arch/sys_arch.h>
 #include <lwip/sys.h>
 #include <lwip/netifapi.h>


### PR DESCRIPTION
У нас есть два errno.h
Один из lwip, а другой смистемный из библиотеки компилятора sys/errno.h
В errno из LwIP некоторы константы не определены.
Часто возникают конфликты из-за переопредлений, потому что в некоторые файлы включается один errno, а в некоторые - другйо errno.
Этот коммит отключает использование errno.h из пакета lwIP